### PR TITLE
fix issue where history_file update would append string "pwd" rather than output of pwd command

### DIFF
--- a/functions/bidopsgitpull
+++ b/functions/bidopsgitpull
@@ -1,0 +1,9 @@
+function BidopsGitPull() {
+	local APPDIR="/Users/andrewjones/bidops/Bid-Ops-Web"
+	
+	cd $APPDIR
+
+	git pull
+}
+
+alias bgp="BidopsGitPull"

--- a/functions/c
+++ b/functions/c
@@ -32,7 +32,7 @@ function c() {
     cd $DIR
   fi
 
-  export CWD=pwd
+  export CWD=$(pwd)
   # update and truncate history file
   if [[ "$CWD" != `tail -n1 $history_file` ]]; then
     # no duplicates

--- a/functions/devserver
+++ b/functions/devserver
@@ -1,9 +1,12 @@
-function DevServer() {
+function DevServers() {
 	local DIR="/Users/andrewjones/bidops/Bid-Ops-Web"
+	local OSACMD='tell application "Terminal" to do script "cd /Users/andrewjones/bidops/Bid-Ops-Web"'
 
+	osascript -e 'tell application "Terminal" to do script "cd '$DIR' && webpack-dev-server"'
 	cd $DIR
-	webpack-dev-server
+	rails s
 
+	
 }
 
-alias ds="DevServer"
+alias ds="DevServers"

--- a/functions/devserver
+++ b/functions/devserver
@@ -1,0 +1,9 @@
+function DevServer() {
+	local DIR="/Users/andrewjones/bidops/Bid-Ops-Web"
+
+	cd $DIR
+	webpack-dev-server
+
+}
+
+alias ds="DevServer"

--- a/functions/devserver
+++ b/functions/devserver
@@ -1,12 +1,10 @@
 function DevServers() {
-	local DIR="/Users/andrewjones/bidops/Bid-Ops-Web"
-	local OSACMD='tell application "Terminal" to do script "cd /Users/andrewjones/bidops/Bid-Ops-Web"'
+	local APPDIR="/Users/andrewjones/bidops/Bid-Ops-Web"
 
-	osascript -e 'tell application "Terminal" to do script "cd '$DIR' && webpack-dev-server"'
+	osascript -e 'tell application "Terminal" to do script "cd '$APPDIR' && webpack-dev-server"'
+	
 	cd $DIR
 	rails s
-
-	
 }
 
 alias ds="DevServers"

--- a/functions/devserver
+++ b/functions/devserver
@@ -3,7 +3,7 @@ function DevServers() {
 
 	osascript -e 'tell application "Terminal" to do script "cd '$APPDIR' && webpack-dev-server"'
 	
-	cd $DIR
+	cd $APPDIR
 	rails s
 }
 


### PR DESCRIPTION
Maybe this is something unique to my bash environment but 
`c -1 `
would not work because ~/.bash_history would only ever contain the line  “pwd”. Investigation revealed that, in my bash environment at least, 

```
export CWD=pwd
echo $CWD
```

would print 
`pwd`

rather than the expected behavior, which is to print the output of pwd command. 

```
export CWD=$(pwd)
echo $CWD
```

Correctly prints the output of the pwd command.
